### PR TITLE
#25 絞り込みオプションの追加

### DIFF
--- a/src/edar/src/App.tsx
+++ b/src/edar/src/App.tsx
@@ -2,15 +2,39 @@ import Header from './components/Header'
 import MainContent from './components/MainContent/MainContent';
 import EdarSiteTop from './components/EdarSiteTop'
 import Footer from './components/Footer'
-function App() {
+import { makeStyles, Theme } from "@material-ui/core/styles";
+
+
+export default function App() {
+  const classes = useStyles();
   return (
-    <div className="App">
-      <Header title="EDAR" subtitle="~ Easily decide on a restaurant ~" />
+    <div className={classes.app}>
+      <div className={classes.center}>
+        <Header title="EDAR" subtitle="~ Easily decide on a restaurant ~" />
+      </div>
       <EdarSiteTop />
-      <MainContent />
+      <div className={classes.center}>
+        <MainContent />
+      </div>
       <Footer title="EDAR" description="~ Easily decide on a restaurant ~" />
     </div>
   );
 }
 
-export default App;
+// CSS-in-JS
+const useStyles = makeStyles((theme: Theme) => ({
+  app: {
+    width: '100%',
+    textAlign: 'center',
+  },
+  center: {
+    width: '960px',
+    margin: '0 auto',
+    textAlign: 'left',
+    [theme.breakpoints.down('sm')]: {
+      width: '100%',
+      margin: '0 auto',
+      textAlign: 'left',
+    }
+  }
+}));

--- a/src/edar/src/components/Header.tsx
+++ b/src/edar/src/components/Header.tsx
@@ -15,10 +15,13 @@ import PropTypes from 'prop-types';
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         toolBar: {
-            minHeight: 36
+            minHeight: 36,
+        },
+        titleBlock: {
+            margin: 'auto',
         },
         subTitle: {
-            color: "#FFCC00",
+            color: "#008000",
             [theme.breakpoints.down('sm')]: {
                 display: 'none',
             }
@@ -56,7 +59,7 @@ function GridMapping(props: gridProps) {
     const classes = useStyles();
     return (
         <Grid container>
-            <Grid item xs={4} sm={4} >
+            <Grid item xs={4} sm={4} className={classes.titleBlock}>
                 <Typography variant="h6">
                     {titles.title}
                 </Typography >

--- a/src/edar/src/components/MainContent/NarrowDown.test.tsx
+++ b/src/edar/src/components/MainContent/NarrowDown.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import NarrowDown from '../MainContent/NarrowDown';
+import { useSelector, useDispatch } from 'react-redux';
+import userEvent from '@testing-library/user-event';
+
+afterEach(cleanup);
+
+jest.mock('../../stores/shopInfomation');
+jest.mock('react-redux');
+const useSelectorMock = useSelector as jest.Mock;
+const useDispatchMock = useDispatch as jest.Mock;
+
+
+type State = {
+    range: string
+}
+
+describe('NarrowDownコンポーネント', () => {
+    const testData: State = {
+        range: '5',
+    };
+
+    beforeEach(() => {
+        useSelectorMock.mockReturnValue(testData);
+        useDispatchMock.mockReturnValue(jest.fn());
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks()
+    });
+
+    test('絞り込みボタンが表示されているか', () => {
+        render(<NarrowDown />);
+        expect(screen.getByTestId('narrowDown')).toBeInTheDocument();
+
+    });
+
+    test('絞り込みボタンが押されて、距離オプションが表示されるか', () => {
+        render(<NarrowDown />);
+        userEvent.click(screen.getByTestId('narrowDown'));
+        expect(screen.getByText('距離')).toBeInTheDocument();
+    });
+
+    test.skip('距離のデフォルト値は「～1000m」であることを目視で確認', () => { });
+
+    test.skip('絞り込みダイアログを表示して、距離を選択して「設定する」を押すとそれに応じてお店表示されるのを目視で確認', () => { });
+
+    test.skip('絞り込みオプションのダイアログ表示して、デフォルト値以外を選んで「キャンセル」を押すと、前回値を設定することを目視で確認', () => { });
+
+});

--- a/src/edar/src/components/MainContent/NarrowDown.test.tsx
+++ b/src/edar/src/components/MainContent/NarrowDown.test.tsx
@@ -13,12 +13,18 @@ const useDispatchMock = useDispatch as jest.Mock;
 
 
 type State = {
-    range: string
+    range: {
+        code: string
+        label: string
+    }
 }
 
 describe('NarrowDownコンポーネント', () => {
     const testData: State = {
-        range: '5',
+        range: {
+            code: '3',
+            label: '～1000m'
+        },
     };
 
     beforeEach(() => {

--- a/src/edar/src/components/MainContent/NarrowDown.tsx
+++ b/src/edar/src/components/MainContent/NarrowDown.tsx
@@ -124,6 +124,7 @@ export default function NarrowDown() {
                     onClick={handleClickNarrowDown}
                     startIcon={<MenuIcon />}
                     className={classes.narrowDownButton}
+                    data-testid="narrowDown"
                 >
                     絞り込み
                 </Button>

--- a/src/edar/src/components/MainContent/NarrowDown.tsx
+++ b/src/edar/src/components/MainContent/NarrowDown.tsx
@@ -35,12 +35,12 @@ function NarrowDownDialogRaw(props: NarrowDownDialogRawProps) {
     const radioGroupRef = useRef<HTMLElement>(null);
     const dispatch = useDispatch();
     const { range } = useSelector((state: RootState) => state.shopInfomation);
-    const [value, setValue] = useState(range);
+    const [code, setCode] = useState(range.code);
 
     // キャンセルを押した際に前回値を再設定
     useEffect(() => {
         if (!isOpenDialog) {
-            setValue(range);
+            setCode(range.code);
         }
     }, [isOpenDialog, range]);
 
@@ -56,11 +56,12 @@ function NarrowDownDialogRaw(props: NarrowDownDialogRawProps) {
 
     const handleOk = () => {
         onClose();
-        dispatch(updateRange(value));
+        let label = distance[Number(code) - 1].label;
+        dispatch(updateRange({ code, label }));
     };
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setValue((event.target as HTMLInputElement).value);
+        setCode((event.target as HTMLInputElement).value);
     };
 
     return (
@@ -80,7 +81,7 @@ function NarrowDownDialogRaw(props: NarrowDownDialogRawProps) {
                     <RadioGroup
                         ref={radioGroupRef}
                         name="narrowDown"
-                        value={value}
+                        value={code}
                         onChange={handleChange}
                     >
                         {distance.map((distance) => (

--- a/src/edar/src/components/MainContent/NarrowDown.tsx
+++ b/src/edar/src/components/MainContent/NarrowDown.tsx
@@ -1,0 +1,161 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogActions from '@material-ui/core/DialogActions';
+import Dialog from '@material-ui/core/Dialog';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import Radio from '@material-ui/core/Radio';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import MenuIcon from '@material-ui/icons/Menu';
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from '../../stores/rootReducer';
+import { updateRange } from '../../stores/shopInfomation';
+
+const distance = [
+    { code: '1', label: '～300m' },
+    { code: '2', label: '～500m' },
+    { code: '3', label: '～1000m' },
+    { code: '4', label: '～2000m' },
+    { code: '5', label: '～3000m' },
+];
+
+export interface NarrowDownDialogRawProps {
+    classes: Record<'paper', string>;
+    id: string;
+    keepMounted: boolean;
+    isOpenDialog: boolean;
+    onClose: () => void;
+}
+
+function NarrowDownDialogRaw(props: NarrowDownDialogRawProps) {
+    const { onClose, isOpenDialog, ...other } = props;
+    const radioGroupRef = useRef<HTMLElement>(null);
+    const dispatch = useDispatch();
+    const { range } = useSelector((state: RootState) => state.shopInfomation);
+    const [value, setValue] = useState(range);
+
+    // キャンセルを押した際に前回値を再設定
+    useEffect(() => {
+        if (!isOpenDialog) {
+            setValue(range);
+        }
+    }, [isOpenDialog, range]);
+
+    const handleEntering = () => {
+        if (radioGroupRef.current != null) {
+            radioGroupRef.current.focus();
+        }
+    };
+
+    const handleCancel = () => {
+        onClose();
+    };
+
+    const handleOk = () => {
+        onClose();
+        dispatch(updateRange(value));
+    };
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setValue((event.target as HTMLInputElement).value);
+    };
+
+    return (
+        <>
+            <Dialog
+                maxWidth="xs"
+                onEntering={handleEntering}
+                onClose={onClose}
+                open={isOpenDialog}
+                {...other}
+            >
+                <DialogTitle id="narrow-down-dialog-title">絞り込み</DialogTitle>
+                <DialogContent dividers>
+                    <DialogContentText>
+                        距離
+                    </DialogContentText>
+                    <RadioGroup
+                        ref={radioGroupRef}
+                        name="narrowDown"
+                        value={value}
+                        onChange={handleChange}
+                    >
+                        {distance.map((distance) => (
+                            <FormControlLabel value={distance.code} key={distance.code} control={<Radio color="primary" />} label={distance.label} />
+                        ))}
+                    </RadioGroup>
+                </DialogContent>
+                <DialogActions>
+                    <Button autoFocus onClick={handleCancel} color="primary">
+                        キャンセル
+                    </Button>
+                    <Button onClick={handleOk} color="primary">
+                        設定する
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+        </>
+    );
+}
+
+export default function NarrowDown() {
+    const classes = useStyles();
+    const [isOpenDialog, setIsOpenDialog] = useState(false);
+
+    const handleClickNarrowDown = () => {
+        setIsOpenDialog(true);
+    };
+
+    const handleClose = () => {
+        setIsOpenDialog(false);
+    };
+
+    return (
+        <>
+            <div className={classes.root}>
+                <Button
+                    variant="outlined"
+                    color="primary"
+                    size='large'
+                    onClick={handleClickNarrowDown}
+                    startIcon={<MenuIcon />}
+                    endIcon={<ArrowDropDownIcon />}
+                    className={classes.narrowDownButton}
+                >
+                    絞り込み
+                </Button>
+                <NarrowDownDialogRaw
+                    classes={{
+                        paper: classes.paper,
+                    }}
+                    id="narrowDown"
+                    keepMounted
+                    isOpenDialog={isOpenDialog}
+                    onClose={handleClose}
+                />
+            </div>
+        </>
+    );
+}
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        root: {
+            width: '100%',
+            maxWidth: 360,
+            backgroundColor: theme.palette.background.paper,
+        },
+        paper: {
+            width: '80%',
+            maxHeight: 435,
+        },
+        narrowDownButton: {
+            height: 45,
+        }
+    }),
+);

--- a/src/edar/src/components/MainContent/NarrowDown.tsx
+++ b/src/edar/src/components/MainContent/NarrowDown.tsx
@@ -26,12 +26,12 @@ export interface NarrowDownDialogRawProps {
     classes: Record<'paper', string>;
     id: string;
     keepMounted: boolean;
-    isOpenDialog: boolean;
-    onClose: () => void;
+    isOpeningDialog: boolean;
+    onCloseDialog: () => void;
 }
 
 function NarrowDownDialogRaw(props: NarrowDownDialogRawProps) {
-    const { onClose, isOpenDialog, ...other } = props;
+    const { onCloseDialog, isOpeningDialog, ...other } = props;
     const radioGroupRef = useRef<HTMLElement>(null);
     const dispatch = useDispatch();
     const { range } = useSelector((state: RootState) => state.shopInfomation);
@@ -39,28 +39,28 @@ function NarrowDownDialogRaw(props: NarrowDownDialogRawProps) {
 
     // キャンセルを押した際に前回値を再設定
     useEffect(() => {
-        if (!isOpenDialog) {
+        if (!isOpeningDialog) {
             setCode(range.code);
         }
-    }, [isOpenDialog, range]);
+    }, [isOpeningDialog, range]);
 
-    const handleEntering = () => {
+    const openedNarrowDownDialog = () => {
         if (radioGroupRef.current != null) {
             radioGroupRef.current.focus();
         }
     };
 
-    const handleCancel = () => {
-        onClose();
+    const canceledNarrowDownDialog = () => {
+        onCloseDialog();
     };
 
-    const handleOk = () => {
-        onClose();
+    const decidedNarrowDownSetting = () => {
+        onCloseDialog();
         let label = distance[Number(code) - 1].label;
         dispatch(updateRange({ code, label }));
     };
 
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const doChangeRange = (event: React.ChangeEvent<HTMLInputElement>) => {
         setCode((event.target as HTMLInputElement).value);
     };
 
@@ -68,9 +68,9 @@ function NarrowDownDialogRaw(props: NarrowDownDialogRawProps) {
         <>
             <Dialog
                 maxWidth="xs"
-                onEntering={handleEntering}
-                onClose={onClose}
-                open={isOpenDialog}
+                onEntering={openedNarrowDownDialog}
+                onClose={onCloseDialog}
+                open={isOpeningDialog}
                 {...other}
             >
                 <DialogTitle id="narrow-down-dialog-title">絞り込み</DialogTitle>
@@ -82,7 +82,7 @@ function NarrowDownDialogRaw(props: NarrowDownDialogRawProps) {
                         ref={radioGroupRef}
                         name="narrowDown"
                         value={code}
-                        onChange={handleChange}
+                        onChange={doChangeRange}
                     >
                         {distance.map((distance) => (
                             <FormControlLabel value={distance.code} key={distance.code} control={<Radio color="primary" />} label={distance.label} />
@@ -90,10 +90,10 @@ function NarrowDownDialogRaw(props: NarrowDownDialogRawProps) {
                     </RadioGroup>
                 </DialogContent>
                 <DialogActions>
-                    <Button autoFocus onClick={handleCancel} color="primary">
+                    <Button autoFocus onClick={canceledNarrowDownDialog} color="primary">
                         キャンセル
                     </Button>
-                    <Button onClick={handleOk} color="primary">
+                    <Button onClick={decidedNarrowDownSetting} color="primary">
                         設定する
                     </Button>
                 </DialogActions>
@@ -105,14 +105,14 @@ function NarrowDownDialogRaw(props: NarrowDownDialogRawProps) {
 
 export default function NarrowDown() {
     const classes = useStyles();
-    const [isOpenDialog, setIsOpenDialog] = useState(false);
+    const [isOpeningDialog, setIsOpeningDialog] = useState(false);
 
-    const handleClickNarrowDown = () => {
-        setIsOpenDialog(true);
+    const clickNarrowDownButton = () => {
+        setIsOpeningDialog(true);
     };
 
-    const handleClose = () => {
-        setIsOpenDialog(false);
+    const onCloseDialog = () => {
+        setIsOpeningDialog(false);
     };
 
     return (
@@ -122,7 +122,7 @@ export default function NarrowDown() {
                     variant="outlined"
                     color="primary"
                     size='large'
-                    onClick={handleClickNarrowDown}
+                    onClick={clickNarrowDownButton}
                     startIcon={<MenuIcon />}
                     className={classes.narrowDownButton}
                     data-testid="narrowDown"
@@ -135,8 +135,8 @@ export default function NarrowDown() {
                     }}
                     id="narrowDown"
                     keepMounted
-                    isOpenDialog={isOpenDialog}
-                    onClose={handleClose}
+                    isOpeningDialog={isOpeningDialog}
+                    onCloseDialog={onCloseDialog}
                 />
             </div>
         </>

--- a/src/edar/src/components/MainContent/NarrowDown.tsx
+++ b/src/edar/src/components/MainContent/NarrowDown.tsx
@@ -9,7 +9,6 @@ import Dialog from '@material-ui/core/Dialog';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import Radio from '@material-ui/core/Radio';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import MenuIcon from '@material-ui/icons/Menu';
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from '../../stores/rootReducer';
@@ -124,7 +123,6 @@ export default function NarrowDown() {
                     size='large'
                     onClick={handleClickNarrowDown}
                     startIcon={<MenuIcon />}
-                    endIcon={<ArrowDropDownIcon />}
                     className={classes.narrowDownButton}
                 >
                     絞り込み
@@ -155,7 +153,7 @@ const useStyles = makeStyles((theme: Theme) =>
             maxHeight: 435,
         },
         narrowDownButton: {
-            height: 45,
+            height: 53,
         }
     }),
 );

--- a/src/edar/src/components/MainContent/RestaurantList.tsx
+++ b/src/edar/src/components/MainContent/RestaurantList.tsx
@@ -65,6 +65,8 @@ export default function RestaurantList() {
                     {isProcessing &&
                         <CircularProgress className={classes.sideInfo} disableShrink />}
                 </Grid>
+            </Grid>
+            <Grid container justify="space-evenly">
                 {shops.map((output: Shop, index: number) => {
                     return (
                         <Grid item key={index}>

--- a/src/edar/src/components/MainContent/SelectGenre.test.tsx
+++ b/src/edar/src/components/MainContent/SelectGenre.test.tsx
@@ -53,7 +53,7 @@ describe('RestaurantListコンポーネント', () => {
 
     test('検索ボタンが表示されているか', () => {
         render(<SelectGenre />);
-        expect(screen.getByText('現在地よりお店を検索')).toBeInTheDocument();
+        expect(screen.getByText('現在地より検索')).toBeInTheDocument();
     });
 
     test('ジャンルのプルダウンを押すとジャンル一覧が表示される', () => {

--- a/src/edar/src/components/MainContent/SelectGenre.test.tsx
+++ b/src/edar/src/components/MainContent/SelectGenre.test.tsx
@@ -20,9 +20,13 @@ type State = {
     url: string
     genre: string
     genreList: Genre[]
+    range: {
+        code: string
+        label: string
+    }
 }
 
-describe('RestaurantListコンポーネント', () => {
+describe('SelectGenreコンポーネント', () => {
     const testData: State = {
         position: {
             latitude: 132,
@@ -40,6 +44,10 @@ describe('RestaurantListコンポーネント', () => {
                 name: 'イタリアン'
             }
         ],
+        range: {
+            code: '3',
+            label: '～1000m'
+        },
     };
 
     beforeEach(() => {

--- a/src/edar/src/components/MainContent/SelectGenre.tsx
+++ b/src/edar/src/components/MainContent/SelectGenre.tsx
@@ -3,6 +3,7 @@ import useEffectCustom from '../../customHooks/useEffectCustom';
 import { Button, InputLabel, Select, FormControl, MenuItem } from '@material-ui/core';
 import { makeStyles, Theme } from "@material-ui/core/styles";
 import Grid from '@material-ui/core/Grid';
+import SearchIcon from '@material-ui/icons/Search';
 import type { Genre } from './MainContent';
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from '../../stores/rootReducer';
@@ -79,8 +80,14 @@ export default function SelectGenre() {
                         <NarrowDown />
                     </Grid>
                     <Grid item xs='auto'>
-                        <Button data-testid="seachButton" type="submit" variant="contained" className={classes.sendButton}>
-                            現在地よりお店を検索
+                        <Button
+                            data-testid="seachButton"
+                            type="submit"
+                            variant="contained"
+                            className={classes.sendButton}
+                            startIcon={<SearchIcon />}
+                        >
+                            現在地より検索
                         </Button>
                     </Grid>
                 </Grid>

--- a/src/edar/src/components/MainContent/SelectGenre.tsx
+++ b/src/edar/src/components/MainContent/SelectGenre.tsx
@@ -101,6 +101,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     sendButton: {
         margin: "12px 0",
         width: "100%",
+        height: 45,
         marginLeft: "auto",
         marginRight: "auto",
     },

--- a/src/edar/src/components/MainContent/SelectGenre.tsx
+++ b/src/edar/src/components/MainContent/SelectGenre.tsx
@@ -8,6 +8,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { RootState } from '../../stores/rootReducer';
 import { createURL, setGenre } from '../../stores/shopInfomation';
 import { fetchPosition, fetchGenreList, fetchShopList } from '../../stores/shopInfomation'
+import NarrowDown from './NarrowDown';
 
 export default function SelectGenre() {
     const classes = useStyles();
@@ -53,9 +54,9 @@ export default function SelectGenre() {
 
     return (
         <>
-            <Grid container spacing={3} alignItems="center" justify="center">
-                <form onSubmit={(event: React.FormEvent<HTMLFormElement>) => getLocationInfo(event)}>
-                    <Grid item>
+            <form onSubmit={(event: React.FormEvent<HTMLFormElement>) => getLocationInfo(event)} className={classes.selectSection}>
+                <Grid container spacing={3} alignItems="center" justify="center">
+                    <Grid item xs='auto'>
                         <FormControl className={classes.formControl}>
                             {/* TODO: (警告が出る) */}
                             <InputLabel htmlFor="select" color="secondary" id="label">ジャンル</InputLabel>
@@ -73,13 +74,16 @@ export default function SelectGenre() {
                             </Select>
                         </FormControl>
                     </Grid>
-                    <Grid>
+                    <Grid item xs='auto'>
+                        <NarrowDown />
+                    </Grid>
+                    <Grid item xs='auto'>
                         <Button data-testid="seachButton" type="submit" variant="contained" className={classes.sendButton}>
                             現在地よりお店を検索
                         </Button>
                     </Grid>
-                </form>
-            </Grid>
+                </Grid>
+            </form>
         </>
     )
 }
@@ -88,7 +92,7 @@ export default function SelectGenre() {
 const useStyles = makeStyles((theme: Theme) => ({
     formControl: {
         margin: theme.spacing(5),
-        minWidth: 200,
+        minWidth: 150,
         marginLeft: "auto",
         marginRight: "auto",
     },
@@ -97,5 +101,10 @@ const useStyles = makeStyles((theme: Theme) => ({
         width: "100%",
         marginLeft: "auto",
         marginRight: "auto",
+    },
+    narrowDown: {
+        width: '250px',
+        margin: '30px',
+        padding: '30px',
     },
 }));

--- a/src/edar/src/components/MainContent/SelectGenre.tsx
+++ b/src/edar/src/components/MainContent/SelectGenre.tsx
@@ -84,10 +84,12 @@ export default function SelectGenre() {
                 <Grid container spacing={3} alignItems="center" justify="center">
                     <Grid item xs='auto' className={classes.option}>
                         <Grid item xs='auto'>
-                            <span className={classes.optionLabel}>エリア</span>現在地
+                            <span className={classes.optionLabel}>エリア</span>
+                            <span>現在地</span>
                         </Grid>
                         <Grid item xs='auto'>
-                            <span className={classes.optionLabel}>範囲</span>{range.label}
+                            <span className={classes.optionLabel}>範囲</span>
+                            <span>{range.label}</span>
                         </Grid>
                     </Grid>
                     <Grid item xs='auto'>

--- a/src/edar/src/components/MainContent/SelectGenre.tsx
+++ b/src/edar/src/components/MainContent/SelectGenre.tsx
@@ -57,13 +57,14 @@ export default function SelectGenre() {
             <form onSubmit={(event: React.FormEvent<HTMLFormElement>) => getLocationInfo(event)} className={classes.selectSection}>
                 <Grid container spacing={3} alignItems="center" justify="center">
                     <Grid item xs='auto'>
-                        <FormControl className={classes.formControl}>
+                        <FormControl className={classes.formControl} variant="outlined">
                             {/* TODO: (警告が出る) */}
-                            <InputLabel htmlFor="select" color="secondary" id="label">ジャンル</InputLabel>
+                            <InputLabel htmlFor="select" color="primary" id="label">ジャンル</InputLabel>
                             <Select
                                 data-testid="select"
                                 id="select"
                                 labelId="label"
+                                label='ジャンル'
                                 value={genre}
                                 onChange={(event: React.ChangeEvent<{ name?: string | undefined, value: any | string }>) => changedgenre(event)}
                                 required
@@ -95,6 +96,7 @@ const useStyles = makeStyles((theme: Theme) => ({
         minWidth: 150,
         marginLeft: "auto",
         marginRight: "auto",
+        backgroundColor: '#fff'
     },
     sendButton: {
         margin: "12px 0",

--- a/src/edar/src/components/MainContent/SelectGenre.tsx
+++ b/src/edar/src/components/MainContent/SelectGenre.tsx
@@ -110,4 +110,7 @@ const useStyles = makeStyles((theme: Theme) => ({
         margin: '30px',
         padding: '30px',
     },
+    selectSection: {
+        backgroundColor: '#fff'
+    }
 }));

--- a/src/edar/src/components/MainContent/SelectGenre.tsx
+++ b/src/edar/src/components/MainContent/SelectGenre.tsx
@@ -18,7 +18,8 @@ export default function SelectGenre() {
         position,
         genre,
         url,
-        genreList
+        genreList,
+        range
     } = useSelector((state: RootState) => state.shopInfomation);
 
     // 経度緯度情報を取得
@@ -58,6 +59,9 @@ export default function SelectGenre() {
             <form onSubmit={(event: React.FormEvent<HTMLFormElement>) => getLocationInfo(event)} className={classes.selectSection}>
                 <Grid container spacing={3} alignItems="center" justify="center">
                     <Grid item xs='auto'>
+                        <NarrowDown />
+                    </Grid>
+                    <Grid item xs='auto'>
                         <FormControl className={classes.formControl} variant="outlined">
                             {/* TODO: (警告が出る) */}
                             <InputLabel htmlFor="select" color="primary" id="label">ジャンル</InputLabel>
@@ -76,8 +80,15 @@ export default function SelectGenre() {
                             </Select>
                         </FormControl>
                     </Grid>
-                    <Grid item xs='auto'>
-                        <NarrowDown />
+                </Grid>
+                <Grid container spacing={3} alignItems="center" justify="center">
+                    <Grid item xs='auto' className={classes.option}>
+                        <Grid item xs='auto'>
+                            <span className={classes.optionLabel}>エリア</span>現在地
+                        </Grid>
+                        <Grid item xs='auto'>
+                            <span className={classes.optionLabel}>範囲</span>{range.label}
+                        </Grid>
                     </Grid>
                     <Grid item xs='auto'>
                         <Button
@@ -100,14 +111,14 @@ export default function SelectGenre() {
 const useStyles = makeStyles((theme: Theme) => ({
     formControl: {
         margin: theme.spacing(5),
-        minWidth: 150,
+        minWidth: 200,
         marginLeft: "auto",
         marginRight: "auto",
         backgroundColor: '#fff'
     },
     sendButton: {
         margin: "12px 0",
-        width: "100%",
+        width: "190px",
         height: 45,
         marginLeft: "auto",
         marginRight: "auto",
@@ -119,5 +130,19 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     selectSection: {
         backgroundColor: '#fff'
-    }
+    },
+    option: {
+        color: '#3cb371',
+        fontSize: '17px',
+        [theme.breakpoints.down('sm')]: {
+            color: '#3cb371',
+            fontSize: '15px',
+        }
+    },
+    optionLabel: {
+        padding: '0px 10px',
+        marginRight: '10px',
+        border: '1px solid #3cb371',
+        borderRadius: '5px',
+    },
 }));

--- a/src/edar/src/stores/shopInfomation.ts
+++ b/src/edar/src/stores/shopInfomation.ts
@@ -17,7 +17,10 @@ type State = {
     genre: string
     genreList: Genre[]
     expanded: boolean[]
-    range: string
+    range: {
+        code: string
+        label: string
+    }
 }
 
 const initialState: State = {
@@ -35,7 +38,10 @@ const initialState: State = {
     genre: '',
     genreList: [],
     expanded: [],
-    range: '3',
+    range: {
+        code: '3',
+        label: '～1000m'
+    },
 };
 
 const slice = createSlice({
@@ -69,7 +75,7 @@ const slice = createSlice({
                 '&lng=' +
                 state.position.longitude +
                 '&range=' +
-                state.range +
+                state.range.code +
                 '&order=1&genre=' +
                 state.genre;
             if (state.url === url) {
@@ -78,7 +84,7 @@ const slice = createSlice({
                 state.url = url;
             }
         },
-        updateRange: (state: State, action: PayloadAction<string>) => {
+        updateRange: (state: State, action: PayloadAction<{ code: string, label: string }>) => {
             state.range = action.payload;
         },
         setShops: (state: State, action: PayloadAction<Shop[]>) => {

--- a/src/edar/src/stores/shopInfomation.ts
+++ b/src/edar/src/stores/shopInfomation.ts
@@ -17,6 +17,7 @@ type State = {
     genre: string
     genreList: Genre[]
     expanded: boolean[]
+    range: string
 }
 
 const initialState: State = {
@@ -34,6 +35,7 @@ const initialState: State = {
     genre: '',
     genreList: [],
     expanded: [],
+    range: '3',
 };
 
 const slice = createSlice({
@@ -66,13 +68,18 @@ const slice = createSlice({
                 state.position.latitude +
                 '&lng=' +
                 state.position.longitude +
-                '&range=4&order=1&genre=' +
+                '&range=' +
+                state.range +
+                '&order=1&genre=' +
                 state.genre;
             if (state.url === url) {
                 state.isProcessing = false;
             } else {
                 state.url = url;
             }
+        },
+        updateRange: (state: State, action: PayloadAction<string>) => {
+            state.range = action.payload;
         },
         setShops: (state: State, action: PayloadAction<Shop[]>) => {
             state.shops = action.payload;
@@ -149,6 +156,7 @@ export const {
     initExpandedList,
     updateExpanded,
     setShopErrorMessage,
+    updateRange,
 } = slice.actions;
 
 // reducerをエクスポート


### PR DESCRIPTION
# 概要
絞り込みオプションとして、範囲を指定できるように追加。

# issue
#25

# 仕様
- 距離は現在地より、300m, 500m, 1000m, 2000m, 3000mと指定でき、デフォルト値は1000mとする。
- 絞り込みボタンを押すと、オプション指定できるダイアログが開く。
- 距離を選択し、設定するボタンを押し、現在地より検索ボタンを押すと、選択距離に応じたお店が表示する。
- ダイアログを表示し、キャンセルボタンを押すと前回値のままとなる。
- ダイアログは、キャンセルボタン以外にも、Escキー、ダイアログ外の画面をクリックすることでもキャンセルと同じと判断される。

# 編集ファイル
- NarrowDown.tsx
  - 絞り込みオプションコンポーネント
  - 絞り込みボタン、ダイアログの表示、距離値の設定を行っている
- shopInfomation.ts
  - APIをたたくのに必要な`range`パラメーターのみをreduxで管理する
- SelectGenre.tsx
  - NarrowDownコンポーネントの親コンポーネント



# デザイン変更
- 検索ボタンに検索アイコンを追加、及び、文言の変更
- ジャンル選択プルダウンのデザインを変更
- 当初は、絞り込みオプションは、下にスライドさせて表示させる予定であったが、material-uiに該当する機能を見つけることができなかったため、ダイアログ表示に変更
- アプリ全体のコンテンツを中央に表示し、左右に余白部分を作った


# 実装画像
## パソコン版
![image](https://user-images.githubusercontent.com/51454617/108187222-93bf2780-7151-11eb-8918-f2f6eadbd204.png)
![image](https://user-images.githubusercontent.com/51454617/108284572-d6701680-71c8-11eb-83f8-79e9161bc53e.png)


## モバイル版
![image](https://user-images.githubusercontent.com/51454617/108187551-ee588380-7151-11eb-81eb-25ba5188ebf1.png)
![image](https://user-images.githubusercontent.com/51454617/108284617-ec7dd700-71c8-11eb-97f3-47dcf6ad2ce4.png)

